### PR TITLE
Fixed Encoding from Unicode to Multibyte

### DIFF
--- a/ftd2xx/ftd2xx.vcproj
+++ b/ftd2xx/ftd2xx.vcproj
@@ -93,7 +93,7 @@
 			OutputDirectory="$(SolutionDir)$(ConfigurationName)"
 			IntermediateDirectory="$(ConfigurationName)"
 			ConfigurationType="2"
-			CharacterSet="1"
+			CharacterSet="2"
 			WholeProgramOptimization="1"
 			>
 			<Tool


### PR DESCRIPTION
Build fails if you don't force Multibyte character set.
